### PR TITLE
Expand $nameservers[addresses] to multi lines

### DIFF
--- a/templates/bonds.epp
+++ b/templates/bonds.epp
@@ -96,7 +96,10 @@
         search: <%= $nameservers[search] %>
       <%- } -%>
       <%- if $nameservers[addresses] { -%>
-        addresses: <%= $nameservers[addresses] %>
+        addresses:
+      <%- $nameservers[addresses].each |$address| { -%>
+          - <%= $address %>
+      <%- } -%>
       <%- } -%>
     <%- } -%>
     <%- if $macaddress { -%>

--- a/templates/bridges.epp
+++ b/templates/bridges.epp
@@ -84,7 +84,10 @@
         search: <%= $nameservers[search] %>
       <%- } -%>
       <%- if $nameservers[addresses] { -%>
-        addresses: <%= $nameservers[addresses] %>
+        addresses:
+      <%- $nameservers[addresses].each |$address| { -%>
+          - <%= $address %>
+      <%- } -%>
       <%- } -%>
     <%- } -%>
     <%- if $macaddress { -%>

--- a/templates/ethernets.epp
+++ b/templates/ethernets.epp
@@ -99,7 +99,10 @@
         search: <%= $nameservers[search] %>
       <%- } -%>
       <%- if $nameservers[addresses] { -%>
-        addresses: <%= $nameservers[addresses] %>
+        addresses:
+      <%- $nameservers[addresses].each |$address| { -%>
+          - <%= $address %>
+      <%- } -%>
       <%- } -%>
     <%- } -%>
     <%- if $macaddress { -%>

--- a/templates/vlans.epp
+++ b/templates/vlans.epp
@@ -94,7 +94,10 @@
         search: <%= $nameservers[search] %>
       <%- } -%>
       <%- if $nameservers[addresses] { -%>
-        addresses: <%= $nameservers[addresses] %>
+        addresses:
+      <%- $nameservers[addresses].each |$address| { -%>
+          - <%= $address %>
+      <%- } -%>
       <%- } -%>
     <%- } -%>
     <%- if $macaddress { -%>

--- a/templates/wifis.epp
+++ b/templates/wifis.epp
@@ -105,7 +105,10 @@
         search: <%= $nameservers[search] %>
       <%- } -%>
       <%- if $nameservers[addresses] { -%>
-        addresses: <%= $nameservers[addresses] %>
+        addresses:
+      <%- $nameservers[addresses].each |$address| { -%>
+          - <%= $address %>
+      <%- } -%>
       <%- } -%>
     <%- } -%>
     <%- if $macaddress { -%>


### PR DESCRIPTION
This avoids needing to quote IPv6 addresses. When the array is all
on one line using [] style, it fails:

```
$ tail -n2 /etc/netplan/01-netcfg.yaml
      nameservers:
        addresses: [1.1.1.1, 2606:4700:4700::1111]

$ sudo netplan apply
Invalid YAML at /etc/netplan/01-netcfg.yaml line 13 column 33: found unexpected ':'
```

but works when expanded into multiple lines:

```
$ tail -n4 /etc/netplan/01-netcfg.yaml
      nameservers:
        addresses:
          - 1.1.1.1
          - 2606:4700:4700::1111

$ sudo netplan apply
$ echo $?
0
```