### PR TITLE
fix_logwatch_module_conflict

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class netplan (
     'renderer'  => $renderer,
   })
 
-  concat::fragment { 'header':
+  concat::fragment { 'netplan_header':
     target  => $netplan::config_file,
     content => $headertmp,
     order   => '01',


### PR DESCRIPTION
Today I installed my first ubuntu server image. I had worked with workstation installs before. By default those all setup as dhcp so I never knew there was a newer network config called netplan until I started to setup the network on my new server. After configuring it manually, I added your module to my Puppetfile and and changed the config to be managed via puppet. The catalog failed because I also use a logwatch module which already used a concat::fragment {'header': } resource.

This PR eliminates that resource conflict and has been successfully tested on my new Ubuntu 18.04 server.
