### PR TITLE
Add support for IPv6 default routes

### DIFF
--- a/manifests/bonds.pp
+++ b/manifests/bonds.pp
@@ -136,7 +136,7 @@ define netplan::bonds (
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -146,7 +146,7 @@ define netplan::bonds (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/manifests/bridges.pp
+++ b/manifests/bridges.pp
@@ -103,7 +103,7 @@ define netplan::bridges (
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -113,7 +113,7 @@ define netplan::bridges (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/manifests/ethernets.pp
+++ b/manifests/ethernets.pp
@@ -107,7 +107,7 @@ define netplan::ethernets (
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0'], Enum['::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -117,7 +117,7 @@ define netplan::ethernets (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0'], Enum['::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/manifests/ethernets.pp
+++ b/manifests/ethernets.pp
@@ -107,7 +107,7 @@ define netplan::ethernets (
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0'], Enum['::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -117,7 +117,7 @@ define netplan::ethernets (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0'], Enum['::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/manifests/vlans.pp
+++ b/manifests/vlans.pp
@@ -102,7 +102,7 @@ define netplan::vlans (
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -112,7 +112,7 @@ define netplan::vlans (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/manifests/wifis.pp
+++ b/manifests/wifis.pp
@@ -116,7 +116,7 @@ define netplan::wifis (
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -126,7 +126,7 @@ define netplan::wifis (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/templates/bonds.epp
+++ b/templates/bonds.epp
@@ -18,7 +18,7 @@
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']          => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                     => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']       => Boolean,
     Optional['metric']        => Integer,
@@ -28,7 +28,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                    => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional[table]           => Integer,
     Optional[priority]        => Integer,
     Optional[fwmark]          => Integer,

--- a/templates/bridges.epp
+++ b/templates/bridges.epp
@@ -18,7 +18,7 @@
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']          => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                     => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']       => Boolean,
     Optional['metric']        => Integer,
@@ -28,7 +28,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                    => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional[table]           => Integer,
     Optional[priority]        => Integer,
     Optional[fwmark]          => Integer,

--- a/templates/ethernets.epp
+++ b/templates/ethernets.epp
@@ -27,7 +27,7 @@
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']          => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                     => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']       => Boolean,
     Optional['metric']        => Integer,
@@ -37,7 +37,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                    => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional[table]           => Integer,
     Optional[priority]        => Integer,
     Optional[fwmark]          => Integer,

--- a/templates/vlans.epp
+++ b/templates/vlans.epp
@@ -18,7 +18,7 @@
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']            => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']         => Boolean,
     Optional['metric']          => Integer,
@@ -28,7 +28,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['fwmark']          => Integer,

--- a/templates/wifis.epp
+++ b/templates/wifis.epp
@@ -27,7 +27,7 @@
   Optional[Boolean]                                               $optional = undef,
   Optional[Array[Struct[{
     Optional['from']          => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     'via'                     => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']       => Boolean,
     Optional['metric']        => Integer,
@@ -37,7 +37,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                    => Stdlib::IP::Address,
-    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0']],
+    'to'                      => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
     Optional[table]           => Integer,
     Optional[priority]        => Integer,
     Optional[fwmark]          => Integer,


### PR DESCRIPTION
::/0 is the default route for IPv6 same as the 0.0.0.0/0 is the default route for IPv4