### PR TITLE
Add support for `critical` netplan option

### DIFF
--- a/manifests/bonds.pp
+++ b/manifests/bonds.pp
@@ -179,6 +179,7 @@ define netplan::bonds (
     Optional['learn_packet_interval']   => String,
     Optional['primary']                 => String,
   }]]                                                             $parameters = undef,
+  Optional[Boolean]                                               $critical = undef,
 
   ){
 
@@ -216,6 +217,7 @@ define netplan::bonds (
     'routing_policy'  => $routing_policy,
     'interfaces'      => $interfaces,
     'parameters'      => $parameters,
+    'critical'        => $critical,
   })
 
   concat::fragment { $name:

--- a/manifests/bridges.pp
+++ b/manifests/bridges.pp
@@ -132,6 +132,7 @@ define netplan::bridges (
     Optional['path_cost']        => Integer,
     Optional['stp']              => Boolean,
   }]]                                                             $parameters = undef,
+  Optional[Boolean]                                               $critical = undef,
 
   ){
 
@@ -168,6 +169,7 @@ define netplan::bridges (
     'routing_policy'  => $routing_policy,
     'interfaces'      => $interfaces,
     'parameters'      => $parameters,
+    'critical'        => $critical,
   })
 
   concat::fragment { $name:

--- a/manifests/ethernets.pp
+++ b/manifests/ethernets.pp
@@ -124,6 +124,7 @@ define netplan::ethernets (
     Optional['fwmark']          => Integer,
     Optional['type_of_service'] => Integer,
   }]]]                                                            $routing_policy = undef,
+  Optional[Boolean]                                               $critical = undef,
 
   ){
 
@@ -162,6 +163,7 @@ define netplan::ethernets (
     'optional'        => $optional,
     'routes'          => $routes,
     'routing_policy'  => $routing_policy,
+    'critical'        => $critical,
   })
 
   concat::fragment { $name:

--- a/manifests/vlans.pp
+++ b/manifests/vlans.pp
@@ -122,6 +122,7 @@ define netplan::vlans (
   # vlans specific properties
   Integer                                                         $id = undef,
   String                                                          $link = undef,
+  Optional[Boolean]                                               $critical = undef,
 
   ) {
 
@@ -158,6 +159,7 @@ define netplan::vlans (
     'routing_policy'  => $routing_policy,
     'id'              => $id,
     'link'            => $link,
+    'critical'        => $critical,
   })
 
   concat::fragment { $name:

--- a/manifests/wifis.pp
+++ b/manifests/wifis.pp
@@ -138,6 +138,7 @@ define netplan::wifis (
     Optional['password']        => String,
     Optional['mode']            => Enum['infrastructure', 'ap', 'adhoc'],
   }]]]                                                            $access_points = undef,
+  Optional[Boolean]                                               $critical = undef,
 
   ){
 
@@ -176,6 +177,7 @@ define netplan::wifis (
     'routes'          => $routes,
     'routing_policy'  => $routing_policy,
     'access_points'   => $access_points,
+    'critical'        => $critical,
   })
 
   concat::fragment { $name:

--- a/templates/bonds.epp
+++ b/templates/bonds.epp
@@ -60,6 +60,7 @@
     Optional['learn_packet_interval']   => String,
     Optional['primary']                 => String,
   }]]                                                             $parameters = undef,
+  Optional[Boolean]                                               $critical = undef,
 
 | -%>
     <%= $name %>:
@@ -207,4 +208,7 @@
         <%- if $parameters[primary] { -%>
         primary: <%= $parameters[primary] %>
         <%- } -%>
+    <%- } -%>
+    <%- unless $critical =~ Undef { -%>
+      critical: <%= $critical %>
     <%- } -%>

--- a/templates/bridges.epp
+++ b/templates/bridges.epp
@@ -47,6 +47,7 @@
     Optional['path_cost']        => Integer,
     Optional['stp']              => Boolean,
   }]]                                                             $parameters = undef,
+  Optional[Boolean]                                               $critical = undef,
 
 | -%>
     <%= $name %>:
@@ -155,4 +156,7 @@
         <%- unless $parameters[stp] =~ Undef { -%>
         stp: <%= $parameters[stp] %>
         <%- } -%>
+    <%- } -%>
+    <%- unless $critical =~ Undef { -%>
+      critical: <%= $critical %>
     <%- } -%>

--- a/templates/ethernets.epp
+++ b/templates/ethernets.epp
@@ -44,6 +44,7 @@
     Optional[fwmark]          => Integer,
     Optional[type_of_service] => Integer,
   }]]]                                                            $routing_policy = undef,
+  Optional[Boolean]                                               $critical = undef,
 
 | -%>
     <%= $name %>:
@@ -143,4 +144,7 @@
           priority: <%= $policy[priority] %>
           <%- } -%>
       <%- } -%>
+    <%- } -%>
+    <%- unless $critical =~ Undef { -%>
+      critical: <%= $critical %>
     <%- } -%>

--- a/templates/vlans.epp
+++ b/templates/vlans.epp
@@ -34,6 +34,7 @@
     Optional['fwmark']          => Integer,
     Optional['type_of_service'] => Integer,
   }]]]                                                            $routing_policy = undef,
+  Optional[Boolean]                                               $critical = undef,
 
   # vlans specific properties
   Integer                                                         $id = undef,
@@ -141,4 +142,7 @@
     <%- } -%>
     <%- if $link { -%>
       link: <%= $link %>
+    <%- } -%>
+    <%- unless $critical =~ Undef { -%>
+      critical: <%= $critical %>
     <%- } -%>

--- a/templates/wifis.epp
+++ b/templates/wifis.epp
@@ -49,6 +49,7 @@
     Optional['password']        => String,
     Optional['mode']            => Enum['infrastructure', 'ap', 'adhoc'],
   }]]]                                                            $access_points = undef,
+  Optional[Boolean]                                               $critical = undef,
 
 | -%>
     <%= $name %>:
@@ -158,4 +159,7 @@
           mode: <%= $setting[mode] %>
           <%- } -%>
       <%- } -%>
+    <%- } -%>
+    <%- unless $critical =~ Undef { -%>
+      critical: <%= $critical %>
     <%- } -%>


### PR DESCRIPTION
This PR adds support for netplan's `critical` option. The option prevents networkd from releasing addresses assigned to an interface. You can find out more about it [here](https://github.com/CanonicalLtd/netplan/blob/master/doc/netplan.md).