### PR TITLE
wait until the network is back up after running 'netplan apply'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,10 +54,18 @@ class netplan (
     default => undef,
   }
 
+  $renderer_service = $renderer ? {
+    'networkd' => 'systemd-networkd',
+    default    => $renderer,
+  }
+
+  $test_command = "while ! /bin/systemctl status ${renderer_service}; do /bin/sleep 1; done"
+
   exec { 'netplan_apply':
-    command     => '/usr/sbin/netplan apply',
+    command     => "/usr/sbin/netplan apply && ${test_command}",
     logoutput   => 'on_failure',
     refreshonly => true,
+    provider    => 'shell',
   }
 
   concat { $netplan::config_file:


### PR DESCRIPTION
After running 'netplan apply', it takes a short while before the network is usable again.

```
root@ubuntu:~# netplan apply && for i in $(seq 1 10); do systemctl status systemd-networkd &> /dev/null; echo $?; done
3
3
3
3
3
3
0
0
0
```
If puppet attempts to use the network during this time (install packages), it results in a failed puppet run. One way to deal with this is to set ordering rules for all the resources outside of this module that could be affected. But I think it makes sense to assume the network is in the desired state when when puppet finishes applying the netplan class. 