### PR TITLE
Enable labels to specified on interface addresses (#2)

### DIFF
--- a/manifests/ethernets.pp
+++ b/manifests/ethernets.pp
@@ -52,6 +52,10 @@
 #  Add static addresses to the interface in addition to the ones received through DHCP or RA.
 #  Each sequence entry is in CIDR notation, i. e. of the form addr/prefixlen. addr is an IPv4 or IPv6
 #  address as recognized by inet_pton(3) and prefixlen the number of bits of the subnet.
+#  Label can also been specified on a per address basis as shown. Requried netplan 0.104 or greater
+#    - 192.168.1.6/24:
+#        label: 'mylabel'
+#    - 192.168.2.6/24
 # @param gateway4
 #  Set default gateway for IPv4, for manual address configuration. This requires setting addresses too.
 # @param gateway6
@@ -155,7 +159,7 @@ define netplan::ethernets (
     Optional['use_domains']     => Variant[Enum['route', 'true', 'false', 'yes', 'no'], Boolean],
   }]]                                                             $dhcp6_overrides = undef,
   Optional[Boolean]                                               $accept_ra = undef,
-  Optional[Array[Stdlib::IP::Address]]                            $addresses = undef,
+  Optional[Array[Variant[Stdlib::IP::Address,Hash[Stdlib::IP::Address,Struct[{label => String[1]}]]]]] $addresses = undef,
   Optional[Stdlib::IP::Address::V4::Nosubnet]                     $gateway4 = undef,
   Optional[Stdlib::IP::Address::V6::Nosubnet]                     $gateway6 = undef,
   Optional[Struct[{

--- a/templates/ethernets.epp
+++ b/templates/ethernets.epp
@@ -43,7 +43,7 @@
     Optional['use_domains']     => Variant[Enum['route', 'true', 'false', 'yes', 'no'], Boolean],
   }]]                                                             $dhcp6_overrides = undef,
   Optional[Boolean]                                               $accept_ra = undef,
-  Optional[Array[Stdlib::IP::Address]]                            $addresses = undef,
+  Optional[Array[Variant[Stdlib::IP::Address,Hash[Stdlib::IP::Address,Struct[{label => String[1]}]]]]] $addresses = undef,
   Optional[Stdlib::IP::Address::V4::Nosubnet]                     $gateway4 = undef,
   Optional[Stdlib::IP::Address::V6::Nosubnet]                     $gateway6 = undef,
   Optional[Struct[{
@@ -197,8 +197,15 @@
     <%- } -%>
     <%- if $addresses { -%>
       addresses:
-      <%- $addresses.each |$address| { -%>
-        - <%= $address %>
+      <%- $addresses.each | $address | { -%>
+        <%- if $address =~ Hash { -%>
+          <%- $address.each | $add, $label | { -%>
+            - <%= $add %>:
+                label: <%= $label['label'] %>
+          <%- } -%>
+      <%- } else { -%>
+            - <%= $address %>
+        <%- } -%>
       <%- } -%>
     <%- } -%>
     <%- if $gateway4 { -%>


### PR DESCRIPTION
Netplan since 0.100 has a new address label feature which permits a label to be specified per address.

This PR enables support for labels in the puppet-netplan module.

Label can be specified as

```
addresses: 
  - 192.168.0.5/24:
       label: 'mylabel'
  - 192.168.2.5/24:
       label: 'myotherlabel'
  - 192.168.3.5/24
```
And can be a combination of label and non label addresses. 

Does not break backwards compatibility. 