### PR TITLE
Add default routing support

### DIFF
--- a/manifests/bonds.pp
+++ b/manifests/bonds.pp
@@ -80,57 +80,57 @@
 # @param interfaces
 #  All devices matching this ID list will be added to the bridge.
 # @param parameters
-#  Customization parameters for special bonding options. Using the NetworkManager renderer, parameter values 
-#  for intervals should be expressed in milliseconds; for the systemd renderer, they should be in seconds 
+#  Customization parameters for special bonding options. Using the NetworkManager renderer, parameter values
+#  for intervals should be expressed in milliseconds; for the systemd renderer, they should be in seconds
 #  unless otherwise specified.
-#  mode: Set the bonding mode used for the interfaces. The default is balance-rr (round robin). Possible values 
+#  mode: Set the bonding mode used for the interfaces. The default is balance-rr (round robin). Possible values
 #    are balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, and balance-alb.
-#  lacp_rate: Set the rate at which LACPDUs are transmitted. This is only useful in 802.3ad mode. 
+#  lacp_rate: Set the rate at which LACPDUs are transmitted. This is only useful in 802.3ad mode.
 #    Possible values are slow (30 seconds, default), and fast (every second).
-#  mii_monitor_interval: Specifies the interval for MII monitoring (verifying if an interface of the bond 
+#  mii_monitor_interval: Specifies the interval for MII monitoring (verifying if an interface of the bond
 #    has carrier). The default is 0; which disables MII monitoring.
 #  min_links: The minimum number of links up in a bond to consider the bond interface to be up.
-#  transmit_hash_policy: Specifies the transmit hash policy for the selection of slaves. This is only 
-#    useful in balance-xor, 802.3ad and balance-tlb modes. 
+#  transmit_hash_policy: Specifies the transmit hash policy for the selection of slaves. This is only
+#    useful in balance-xor, 802.3ad and balance-tlb modes.
 #    Possible values are layer2, layer3+4, layer2+3, encap2+3, and encap3+4.
-#  ad_select: Set the aggregation selection mode. Possible values are stable, bandwidth, and count. This option 
+#  ad_select: Set the aggregation selection mode. Possible values are stable, bandwidth, and count. This option
 #    is only used in 802.3ad mode.
-#  all_slaves_active: If the bond should drop duplicate frames received on inactive ports, set this option to 
-#    false. If they should be delivered, set this option to true. The default value is false, 
+#  all_slaves_active: If the bond should drop duplicate frames received on inactive ports, set this option to
+#    false. If they should be delivered, set this option to true. The default value is false,
 #    and is the desirable behavior in most situations.
-#  arp_interval: Set the interval value for how frequently ARP link monitoring should happen. 
+#  arp_interval: Set the interval value for how frequently ARP link monitoring should happen.
 #    The default value is 0, which disables ARP monitoring.
-#  arp_ip_targets: IPs of other hosts on the link which should be sent ARP requests in order to validate 
-#    that a slave is up. This option is only used when arp-interval is set to a value other than 0. 
-#    At least one IP address must be given for ARP link monitoring to function. Only IPv4 addresses are supported. 
+#  arp_ip_targets: IPs of other hosts on the link which should be sent ARP requests in order to validate
+#    that a slave is up. This option is only used when arp-interval is set to a value other than 0.
+#    At least one IP address must be given for ARP link monitoring to function. Only IPv4 addresses are supported.
 #    You can specify up to 16 IP addresses. The default value is an empty list.
-#  arp_validate: Configure how ARP replies are to be validated when using ARP link monitoring. 
+#  arp_validate: Configure how ARP replies are to be validated when using ARP link monitoring.
 #    Possible values are none, active, backup, and all.
-#  arp_all_targets: Specify whether to use any ARP IP target being up as sufficient for a slave to be considered up; 
-#    or if all the targets must be up. This is only used for active-backup mode when arp-validate is enabled. 
+#  arp_all_targets: Specify whether to use any ARP IP target being up as sufficient for a slave to be considered up;
+#    or if all the targets must be up. This is only used for active-backup mode when arp-validate is enabled.
 #    Possible values are any and all.
 #  up_delay: Specify the delay before enabling a link once the link is physically up. The default value is 0.
 #  down_delay: Specify the delay before disabling a link once the link has been lost. The default value is 0.
-#  fail_over_mac_policy: Set whether to set all slaves to the same MAC address when adding them to the bond, 
+#  fail_over_mac_policy: Set whether to set all slaves to the same MAC address when adding them to the bond,
 #    or how else the system should handle MAC addresses. The possible values are none, active, and follow.
-#  gratuitious_arp: Specify how many ARP packets to send after failover. Once a link is up on a new slave, 
-#    a notification is sent and possibly repeated if this value is set to a number greater than 1. The default value 
+#  gratuitious_arp: Specify how many ARP packets to send after failover. Once a link is up on a new slave,
+#    a notification is sent and possibly repeated if this value is set to a number greater than 1. The default value
 #    is 1 and valid values are between 1 and 255. This only affects active-backup mode.
-#  packets_per_slave: In balance-rr mode, specifies the number of packets to transmit on a slave before switching 
-#    to the next. When this value is set to 0, slaves are chosen at random. Allowable values are between 0 and 65535. 
+#  packets_per_slave: In balance-rr mode, specifies the number of packets to transmit on a slave before switching
+#    to the next. When this value is set to 0, slaves are chosen at random. Allowable values are between 0 and 65535.
 #    The default value is 1. This setting is only used in balance-rr mode.
-#  primary_reselect_policy: Set the reselection policy for the primary slave. On failure of the active slave, the 
-#    system will use this policy to decide how the new active slave will be chosen and how recovery will be handled. 
+#  primary_reselect_policy: Set the reselection policy for the primary slave. On failure of the active slave, the
+#    system will use this policy to decide how the new active slave will be chosen and how recovery will be handled.
 #    The possible values are always, better, and failure.
-#  resend_igmp: In modes balance-rr, active-backup, balance-tlb and balance-alb, a failover can switch IGMP traffic 
+#  resend_igmp: In modes balance-rr, active-backup, balance-tlb and balance-alb, a failover can switch IGMP traffic
 #    from one slave to another.
-#    This parameter specifies how many IGMP membership reports are issued on a failover event. Values range 
-#    from 0 to 255. 0 disables sending membership reports. Otherwise, the first membership report is sent on 
+#    This parameter specifies how many IGMP membership reports are issued on a failover event. Values range
+#    from 0 to 255. 0 disables sending membership reports. Otherwise, the first membership report is sent on
 #    failover and subsequent reports are sent at 200ms intervals.
-#  learn_packet_interval: Specify the interval between sending learning packets to each slave. The value range is 
+#  learn_packet_interval: Specify the interval between sending learning packets to each slave. The value range is
 #    between 1 and 0x7fffffff. The default value is 1. This option only affects balance-tlb and balance-alb modes.
-#  primary: Specify a device to be used as a primary slave, or preferred device to use as a slave for the bond 
-#    (ie. the preferred device to send data through), whenever it is available. 
+#  primary: Specify a device to be used as a primary slave, or preferred device to use as a slave for the bond
+#    (ie. the preferred device to send data through), whenever it is available.
 #    This only affects active-backup, balance-alb, and balance-tlb modes.
 #
 define netplan::bonds (
@@ -181,7 +181,7 @@ define netplan::bonds (
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -194,7 +194,7 @@ define netplan::bonds (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/manifests/bridges.pp
+++ b/manifests/bridges.pp
@@ -80,24 +80,24 @@
 # @param interfaces
 #  All devices matching this ID list will be added to the bridge.
 # @param parameters
-#  Customization parameters for special bridging options. Using the NetworkManager renderer, parameter values 
-#  for time intervals should be expressed in milliseconds; for the systemd renderer, they should be in seconds 
+#  Customization parameters for special bridging options. Using the NetworkManager renderer, parameter values
+#  for time intervals should be expressed in milliseconds; for the systemd renderer, they should be in seconds
 #  unless otherwise specified.
 #  ageing_time: Set the period of time to keep a MAC address in the forwarding database after a packet is received.
-#  priority: Set the priority value for the bridge. This value should be a number between 0 and 65535. 
+#  priority: Set the priority value for the bridge. This value should be a number between 0 and 65535.
 #    Lower values mean higher priority. The bridge with the higher priority will be elected as the root bridge.
-#  port_priority: Set the port priority to . The priority value is a number between 0 and 63. 
+#  port_priority: Set the port priority to . The priority value is a number between 0 and 63.
 #    This metric is used in the designated port and root port selection algorithms.
-#  forward_delay: Specify the period of time the bridge will remain in Listening and Learning states before 
-#    getting to the Forwarding state. This value should be set in seconds for the systemd backend, and in 
+#  forward_delay: Specify the period of time the bridge will remain in Listening and Learning states before
+#    getting to the Forwarding state. This value should be set in seconds for the systemd backend, and in
 #    milliseconds for the NetworkManager backend.
-#  hello_time: Specify the interval between two hello packets being sent out from the root and designated bridges. 
+#  hello_time: Specify the interval between two hello packets being sent out from the root and designated bridges.
 #    Hello packets communicate information about the network topology.
-#  max_age: Set the maximum age of a hello packet. If the last hello packet is older than that value, 
+#  max_age: Set the maximum age of a hello packet. If the last hello packet is older than that value,
 #    the bridge will attempt to become the root bridge.
-#  path_cost: Set the cost of a path on the bridge. Faster interfaces should have a lower cost. This allows a 
+#  path_cost: Set the cost of a path on the bridge. Faster interfaces should have a lower cost. This allows a
 #    finer control on the network topology so that the fastest paths are available whenever possible.
-#  stp: Define whether the bridge should use Spanning Tree Protocol. The default value is "true", which means that 
+#  stp: Define whether the bridge should use Spanning Tree Protocol. The default value is "true", which means that
 #    Spanning Tree should be used.
 #
 define netplan::bridges (
@@ -148,7 +148,7 @@ define netplan::bridges (
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -161,7 +161,7 @@ define netplan::bridges (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/manifests/ethernets.pp
+++ b/manifests/ethernets.pp
@@ -5,20 +5,20 @@
 # @note intended to be used only by netplan class
 #
 # @param match
-#  This selects a subset of available physical devices by various hardware properties. 
-#  The following configuration will then apply to all matching devices, as soon as they appear. 
-#  All specified properties must match. 
-#  name: Current interface name. Globs are supported, and the primary use case for matching on names, 
-#    as selecting one fixed name can be more easily achieved with having no match: at all and just using 
+#  This selects a subset of available physical devices by various hardware properties.
+#  The following configuration will then apply to all matching devices, as soon as they appear.
+#  All specified properties must match.
+#  name: Current interface name. Globs are supported, and the primary use case for matching on names,
+#    as selecting one fixed name can be more easily achieved with having no match: at all and just using
 #    the ID (see above). Note that currently only networkd supports globbing, NetworkManager does not.
 #  macaddress: Device’s MAC address in the form "XX:XX:XX:XX:XX:XX". Globs are not allowed.
-#  driver: Kernel driver name, corresponding to the DRIVER udev property. Globs are supported. 
+#  driver: Kernel driver name, corresponding to the DRIVER udev property. Globs are supported.
 #    Matching on driver is only supported with networkd.
 # @param set_name
-#  When matching on unique properties such as path or MAC, or with additional assumptions such as 
-#  "there will only ever be one wifi device", match rules can be written so that they only match one device. 
-#  Then this property can be used to give that device a more specific/desirable/nicer name than the default 
-#  from udev’s ifnames. Any additional device that satisfies the match rules will then fail to get renamed 
+#  When matching on unique properties such as path or MAC, or with additional assumptions such as
+#  "there will only ever be one wifi device", match rules can be written so that they only match one device.
+#  Then this property can be used to give that device a more specific/desirable/nicer name than the default
+#  from udev’s ifnames. Any additional device that satisfies the match rules will then fail to get renamed
 #  and keep the original kernel name (and dmesg will show an error).
 # @param wakeonlan
 #  Enable wake on LAN. Off by default.
@@ -168,7 +168,7 @@ define netplan::ethernets (
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -181,7 +181,7 @@ define netplan::ethernets (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/manifests/tunnels.pp
+++ b/manifests/tunnels.pp
@@ -17,7 +17,7 @@
 # @param link_local
 #  Configure the link-local addresses to bring up. Valid options are ‘ipv4’ and ‘ipv6’.
 # @param critical
-#  (networkd backend only) Designate the connection as "critical to the system", meaning that special 
+#  (networkd backend only) Designate the connection as "critical to the system", meaning that special
 #  care will be taken by systemd-networkd to not release the IP from DHCP when the daemon is restarted.
 # @param dhcp_identifier
 #  When set to ‘mac’; pass that setting over to systemd-networkd to use the device’s MAC address as a
@@ -78,8 +78,8 @@
 #  type_of_service: Match this policy rule based on the type of service number applied to the traffic.
 #
 # @param mode
-#  Defines the tunnel mode. Valid options are sit, gre, ip6gre, ipip, ipip6, ip6ip6, vti, and vti6. Additionally, 
-#  the networkd backend also supports gretap and ip6gretap modes. In addition, the NetworkManager backend supports 
+#  Defines the tunnel mode. Valid options are sit, gre, ip6gre, ipip, ipip6, ip6ip6, vti, and vti6. Additionally,
+#  the networkd backend also supports gretap and ip6gretap modes. In addition, the NetworkManager backend supports
 #  isatap tunnels.
 # @param local
 #  Defines the address of the local endpoint of the tunnel.
@@ -88,8 +88,8 @@
 # @param ttl
 #  Defines the ttl of the tunnel.
 # @param key
-#  Define keys to use for the tunnel. The key can be a number or a dotted quad (an IPv4 address). It is used for 
-#  identification of IP transforms. This is only required for vti and vti6 when using the networkd backend, and 
+#  Define keys to use for the tunnel. The key can be a number or a dotted quad (an IPv4 address). It is used for
+#  identification of IP transforms. This is only required for vti and vti6 when using the networkd backend, and
 #  for gre or ip6gre tunnels when using the NetworkManager backend.
 # @param keys
 #  You can further specify input and output:
@@ -144,7 +144,7 @@ define netplan::tunnels (
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -157,7 +157,7 @@ define netplan::tunnels (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/manifests/vlans.pp
+++ b/manifests/vlans.pp
@@ -130,7 +130,7 @@ define netplan::vlans (
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -143,7 +143,7 @@ define netplan::vlans (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/manifests/wifis.pp
+++ b/manifests/wifis.pp
@@ -97,23 +97,23 @@
 #  type_of_service: Match this policy rule based on the type of service number applied to the traffic.
 #
 # @param access-points
-#  This provides pre-configured connections to NetworkManager. Note that users can of course select other 
-#  access points/SSIDs. The keys of the mapping are the SSIDs, and the values are mappings with the following 
+#  This provides pre-configured connections to NetworkManager. Note that users can of course select other
+#  access points/SSIDs. The keys of the mapping are the SSIDs, and the values are mappings with the following
 #  supported properties:
-#  password: Enable WPA2 authentication and set the passphrase for it. If not given, the network is 
+#  password: Enable WPA2 authentication and set the passphrase for it. If not given, the network is
 #    assumed to be open. Other authentication modes are not currently supported.
-#  mode: Possible access point modes are infrastructure (the default), ap (create an access point to which 
-#    other devices can connect), and adhoc (peer to peer networks without a central access point). 
+#  mode: Possible access point modes are infrastructure (the default), ap (create an access point to which
+#    other devices can connect), and adhoc (peer to peer networks without a central access point).
 #    ap is only supported with NetworkManager.
-#  auth: 
-#    key_management: he supported key management modes are none (no key management); psk (WPA with 
-#      pre-shared key, common for home wifi); eap (WPA with EAP, common for enterprise wifi); 
+#  auth:
+#    key_management: he supported key management modes are none (no key management); psk (WPA with
+#      pre-shared key, common for home wifi); eap (WPA with EAP, common for enterprise wifi);
 #      and 802.1x (used primarily for wired Ethernet connections).
 #    password: The password string for EAP, or the pre-shared key for WPA-PSK.
-#    method: The EAP method to use. The supported EAP methods are tls (TLS), peap (Protected EAP), 
+#    method: The EAP method to use. The supported EAP methods are tls (TLS), peap (Protected EAP),
 #      and ttls (Tunneled TLS).
 #    identity: The identity to use for EAP.
-#    anonymous_identity: The identity to pass over the unencrypted channel if the chosen EAP method 
+#    anonymous_identity: The identity to pass over the unencrypted channel if the chosen EAP method
 #      supports passing a different tunnelled identity.
 #    ca_certificate: Path to a file with one or more trusted certificate authority (CA) certificates.
 #    client_certificate: Path to a file containing the certificate to be used by the client during authentication.
@@ -177,7 +177,7 @@ define netplan::wifis (
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -190,7 +190,7 @@ define netplan::wifis (
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/templates/bonds.epp
+++ b/templates/bonds.epp
@@ -47,7 +47,7 @@
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -60,7 +60,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/templates/bridges.epp
+++ b/templates/bridges.epp
@@ -1,4 +1,4 @@
-<%- | 
+<%- |
   String                                                          $name,
 
   # common properties
@@ -47,7 +47,7 @@
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -60,7 +60,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,

--- a/templates/ethernets.epp
+++ b/templates/ethernets.epp
@@ -1,4 +1,4 @@
-<%- | 
+<%- |
   String                                                          $name,
 
   # common properties for physical devices
@@ -56,7 +56,7 @@
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -69,7 +69,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,
@@ -282,7 +282,7 @@
           priority: <%= $policy[priority] %>
           <%- } -%>
       <%- } -%>
-    <%- } -%>    
+    <%- } -%>
     <%# ethernets specific properties -%>
     <%- if $auth { -%>
       auth:
@@ -313,4 +313,4 @@
         <%- if $auth[client_key_password] { -%>
         client-key-password: "<%= $auth[client_key_password] %>"
         <%- } -%>
-    <%- } -%>    
+    <%- } -%>

--- a/templates/tunnels.epp
+++ b/templates/tunnels.epp
@@ -1,4 +1,4 @@
-<%- | 
+<%- |
   String                                                          $name,
 
   # common properties
@@ -47,7 +47,7 @@
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -60,7 +60,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,
@@ -167,7 +167,7 @@
       accept-ra: <%= $accept_ra %>
     <%- } -%>
     <%- if $addresses { -%>
-      addresses: 
+      addresses:
       <%- $addresses.each |$address| { -%>
         - <%= $address %>
       <%- } -%>

--- a/templates/vlans.epp
+++ b/templates/vlans.epp
@@ -1,4 +1,4 @@
-<%- | 
+<%- |
   String                                                          $name,
 
   # common properties
@@ -47,7 +47,7 @@
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -60,7 +60,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,
@@ -245,7 +245,7 @@
           priority: <%= $policy[priority] %>
           <%- } -%>
       <%- } -%>
-    <%- } -%>    
+    <%- } -%>
     <%# properties for vlans -%>
     <%- if $id { -%>
       id: <%= $id %>

--- a/templates/wifis.epp
+++ b/templates/wifis.epp
@@ -1,4 +1,4 @@
-<%- | 
+<%- |
   String                                                          $name,
 
   # common properties for physical devices
@@ -56,7 +56,7 @@
   Optional[Array[String]]                                         $optional_addresses = undef,
   Optional[Array[Struct[{
     Optional['from']                      => Stdlib::IP::Address,
-    'to'                                  => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                                  => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['via']                       => Stdlib::IP::Address::Nosubnet,
     Optional['on_link']                   => Boolean,
     Optional['metric']                    => Integer,
@@ -69,7 +69,7 @@
   }]]]                                                            $routes = undef,
   Optional[Array[Struct[{
     'from'                      => Stdlib::IP::Address,
-    'to'                        => Variant[Stdlib::IP::Address, Enum['0.0.0.0/0', '::/0']],
+    'to'                        => Variant[Stdlib::IP::Address, Enum['default', '0.0.0.0/0', '::/0']],
     Optional['table']           => Integer,
     Optional['priority']        => Integer,
     Optional['mark']            => Integer,
@@ -286,7 +286,7 @@
           priority: <%= $policy[priority] %>
           <%- } -%>
       <%- } -%>
-    <%- } -%>    
+    <%- } -%>
     <%# wifis specific properties -%>
     <%- if $access_points { -%>
       access-points:
@@ -299,7 +299,7 @@
           mode: <%= $setting[mode] %>
           <%- } -%>
           <%- if $setting[auth] { -%>
-          auth: 
+          auth:
             <%- if $setting[auth][key_management] { -%>
             key-management: <%= $setting[auth][key_management] %>
             <%- } -%>


### PR DESCRIPTION
Since version 0.103 the `gateway4` and `gateway6` are deprecated in favor of `default` see https://github.com/canonical/netplan/pull/216

For this reason I added `default` and for backwards compatibility I left the `gateway4` and `gateway6` in it maybe in a later release remove it when it is really not working any more? Or should we remove it right now?
