### PR TITLE
Manage installation of netplan.io package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,13 @@
 #  whether or not to apply the changes
 # @param purge_config
 #  whether or not to purge the netplan directory
+# @param package_manage
+#  whether to manage the netplan package, default value: true
+# @param package_name
+#  specifies the name of the netplan package to manage, default value: 'netplan.io'
+# @param package_ensure
+#  specifies the state of the netplan package, e.g. 'installed', 'latest' or a specific version.
+#  default value: 'installed'
 #
 class netplan (
   Optional[Hash]       $ethernets = undef,
@@ -49,7 +56,17 @@ class netplan (
   Integer              $version = 2,
   Boolean              $netplan_apply = true,
   Boolean              $purge_config = true,
+  Boolean              $package_manage = true,
+  String               $package_name = 'netplan.io',
+  String               $package_ensure = 'installed',
   ){
+
+  if $package_manage {
+    package { $package_name:
+      ensure => $package_ensure,
+      before => Exec['netplan_apply'],
+    }
+  }
 
   file { '/etc/netplan':
     ensure => directory,


### PR DESCRIPTION
This eases the use of this module on other distributions where netplan is not installed by default, like Debian.

With the 3 new parameters (`package_manage`, `package_name`, `package_ensure`) the package installation can be controlled in a granular way.

`package_manage` defaults to `true`, thus the package will be managed by Puppet on existing installations.
This might be a breaking change.
If you wish to keep the current behaviour of not managing the package, I can change the default to `false`.